### PR TITLE
fixed InheritanceSpecifier

### DIFF
--- a/workspace/com.dell.research.bc.eth.solidity.editor/src/com/dell/research/bc/eth/solidity/editor/Solidity.xtext
+++ b/workspace/com.dell.research.bc.eth.solidity.editor/src/com/dell/research/bc/eth/solidity/editor/Solidity.xtext
@@ -52,7 +52,7 @@ DefinitionBody:
     "}";
 
 InheritanceSpecifier:
-    superType=[ContractOrLibrary] args=FunctionCallListArguments;
+    superType=[ContractOrLibrary] (args=FunctionCallListArguments)?;
 
 FunctionCallListArguments:
     "(" {FunctionCallListArguments} (arguments+=Expression ("," arguments+=Expression)*)? ")";


### PR DESCRIPTION
Fixed the compiler behavior by making the args optional,
this way

```
contract xx is yy {
```

is valid.
